### PR TITLE
Fix behavior of push for sub-arrays

### DIFF
--- a/__test__/index.js
+++ b/__test__/index.js
@@ -343,9 +343,9 @@ test.arrays.mutator('push', ({deepEqual}) => {
 
   let arr = [1,2];
   let immuArr = immu(arr);
-  let pushedImmuArr = immuArr.push(3, 4);
+  let pushedImmuArr = immuArr.push(3, 4, [5, 6]);
 
-  deepEqual(pushedImmuArr, [1,2,3,4], 'pushed values on array');
+  deepEqual(pushedImmuArr, [1,2,3,4,[5,6]], 'pushed values on array');
   deepEqual(immuArr, [1,2], 'did not mutate original array');
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ function immuArrProps (data, definedProps) {
       definedProps[name] = defProp(name, () => (...args) => immu(data[name](...args)));
     });
 
-  definedProps.push = defProp('push', () => (...args) => immu(data.concat(...args)));
+  definedProps.push = defProp('push', () => (...args) => immu(data.concat(args)));
   definedProps.unshift = defProp('unshift', () => (...args) => immu(args.concat(data)));
 
   definedProps.sort = defProp('sort', () => {


### PR DESCRIPTION
Update the `push` method for `immu`'ed arrays to properly handle nested
arrays. For example, pushing `[3, 4]` onto an immu array of `[1, 2]`
should result in the array `[3, 4]` being pushed as a single value, not
as 3 and 4 individually.

Fixes #15
